### PR TITLE
Description of `cycles` option is wrong

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ Default: `false`
 
 Determinate how to resolve cycles.
 
-Under `false`, when a cycle is detected, `[Circular]` will be inserted in the node.
+Under `true`, when a cycle is detected, `[Circular]` will be inserted in the node.
 
 ##### opts.compare
 


### PR DESCRIPTION
`[Circular]` will be inserted in the node, when `opts.cycles` set to `true`, not `false`.